### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 indent() {
     sed -u 's/^/       /'
 }
@@ -30,8 +34,8 @@ if [ -f "${PREP_SCRIPT_FILE}" ]; then
 fi
 
 (
-    mv "${BUILD_DIR}" "${STAGE}" &&
-    cp -RL "${STAGE}/$(basename "${BUILD_DIR}")/${APP_BASE}" "${BUILD_DIR}"
+    mv "${BUILD_DIR}"/* "${STAGE}/" &&
+    cp -RL "${STAGE}/${APP_BASE}"/* "${BUILD_DIR}"/
 )
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Monorepo app detected
remote: rm: cannot remove '/app': Read-only file system
remote:       FAILED to copy directory into place
remote:  !     Push rejected, failed to compile Monorepo app.
```

A fix for this compatibility issue has been merged into the upstream repositories from which this one is forked:
formsort/heroku-buildpack-monorepo/pull/1

This PR merges that fix from the upstream repository back to this fork, so as to avoid any disruption to your builds in the future.

If you would like to avoid the merge commit from this PR (so that the two repository's Git histories do not diverge), then I'd recommend closing this PR as unmerged, and instead pulling upstream directly into `master` of this repo.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
lstoll/heroku-buildpack-monorepo/issues/12

I'm also happy to answer any questions you may have via discussion on this PR :-)